### PR TITLE
Mirror video when using front camera

### DIFF
--- a/BBMetalImage/BBMetalImage/BBMetalCamera.swift
+++ b/BBMetalImage/BBMetalImage/BBMetalCamera.swift
@@ -438,6 +438,12 @@ public class BBMetalCamera: NSObject {
             connection.isVideoOrientationSupported else { return false }
         connection.videoOrientation = .portrait
         
+        if position == .front && connection.isVideoMirroringSupported {
+            connection.isVideoMirrored = true
+        } else {
+            connection.isVideoMirrored = false
+        }
+        
         return true
     }
     

--- a/BBMetalImageDemo/BBMetalImageDemo/CameraFilterVC.swift
+++ b/BBMetalImageDemo/BBMetalImageDemo/CameraFilterVC.swift
@@ -90,6 +90,12 @@ class CameraFilterVC: UIViewController {
     
     @objc private func tapMetalView(_ tap: UITapGestureRecognizer) {
         camera.switchCameraPosition()
+        
+        if camera.position == .front {
+            metalView.transform = CGAffineTransform(scaleX: -1, y: 1)
+        } else {
+            metalView.transform = CGAffineTransform(scaleX: 1, y: 1)
+        }
     }
     
     @objc private func clickFilterButton(_ button: UIButton) {


### PR DESCRIPTION
The resulting video won't be mirrored when the front camera is used - unlike Snapchat, Instagram, etc. do it. I would suggest changing the mirroring when using the front camera. Now, however, the mirroring looks weird while recording so I added a transform to the `metalView` when the front camera is being used (although I'm sure there are more elegant solutions to achieve this more generally).