### PR TITLE
Support mac catalyst in video writer

### DIFF
--- a/BBMetalImage/BBMetalImage/BBMetalVideoWriter.swift
+++ b/BBMetalImage/BBMetalImage/BBMetalVideoWriter.swift
@@ -103,6 +103,9 @@ public class BBMetalVideoWriter {
         descriptor.width = frameSize.width
         descriptor.height = frameSize.height
         descriptor.usage = [.shaderRead, .shaderWrite]
+        #if targetEnvironment(macCatalyst)
+        descriptor.storageMode = .managed
+        #endif
         outputTexture = BBMetalDevice.sharedDevice.makeTexture(descriptor: descriptor)
         
         threadgroupSize = MTLSize(width: 16, height: 16, depth: 1)
@@ -306,6 +309,12 @@ extension BBMetalVideoWriter: BBMetalImageConsumer {
         encoder.setTexture(texture.metalTexture, index: 1)
         encoder.dispatchThreadgroups(threadgroupCount, threadsPerThreadgroup: threadgroupSize)
         encoder.endEncoding()
+        
+        #if targetEnvironment(macCatalyst)
+        let blitEncoder = commandBuffer.makeBlitCommandEncoder()
+        blitEncoder?.synchronize(resource: outputTexture)
+        blitEncoder?.endEncoding()
+        #endif
         
         commandBuffer.commit()
         commandBuffer.waitUntilCompleted() // Wait to make sure that output texture contains new data


### PR DESCRIPTION
Blit synchronizes memory between GPU and CPU, which is required on macOS. Without this step output videos will be blank.